### PR TITLE
[EJP-11-fix1] Definir tipo do parâmetro 'any' no método map

### DIFF
--- a/backend/src/controllers/usuarioController.ts
+++ b/backend/src/controllers/usuarioController.ts
@@ -15,7 +15,7 @@ export const usuarioController = {
     try {
       const usuarios = await usuarioService.getAllUsers();
       // Remova a senha de cada usuário antes de enviar a resposta
-      const usuariosSemSenha = usuarios.map(usuario => {
+      const usuariosSemSenha = usuarios.map((usuario: any) => {
         const { senha, ...usuarioSemSenha } = usuario;
         return usuarioSemSenha;
       });


### PR DESCRIPTION
- Problema:
	Ao rodar o comando **RUN npm run build**, no deploy, apresentava o seguindo erro:
	```
	...
	2.381 src/controllers/usuarioController.ts(18,45): error TS7006: Parameter 'usuario' implicitly has an 'any' type.
	...
	```

- Imagem do erro:

![error](https://github.com/user-attachments/assets/f2e36b7f-56f4-4b56-ba97-d285726cb357)

- Solução:
Corrige a rota **[GET /users] (buscar todos usuários) #11**, adicionando tipo do parâmetro 'any' no método map.